### PR TITLE
Add setup and destroy scripts for Gateway API scenarios

### DIFF
--- a/lessons/gateway-api/scenarios/01/destroy.sh
+++ b/lessons/gateway-api/scenarios/01/destroy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Step 1: Delete the 'prod' namespace (includes all resources inside)
+echo "Deleting 'prod' namespace..."
+kubectl delete namespace prod --ignore-not-found
+
+# Step 2: Remove the line from /etc/hosts
+HOST_ENTRY="172.30.1.2 prod.techiescamp.com"
+echo "Removing host entry from /etc/hosts..."
+sudo sed -i.bak "/$HOST_ENTRY/d" /etc/hosts && echo "Entry removed." || echo "Entry not found."
+
+echo "Cleanup complete. CRDs and NGINX Gateway Fabric remain untouched."

--- a/lessons/gateway-api/scenarios/01/setup.sh
+++ b/lessons/gateway-api/scenarios/01/setup.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+# Step 1: Install Gateway API CRDs if not already present
+echo "Checking for Gateway API CRDs..."
+if ! kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+  echo "Installing Gateway API CRDs..."
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+else
+  echo "Gateway API CRDs already installed. Skipping..."
+fi
+
+# Step 2: Install NGINX Gateway Fabric if not already installed
+echo "Checking for NGINX Gateway Fabric release..."
+if ! helm list -n nginx-gateway | grep -q "^ngf"; then
+  echo "Installing NGINX Gateway Fabric..."
+  helm install ngf oci://ghcr.io/nginxinc/charts/nginx-gateway-fabric --create-namespace -n nginx-gateway
+else
+  echo "NGINX Gateway Fabric already installed. Skipping..."
+fi
+
+# Step 3: Create 'prod' namespace if it doesn't exist
+echo "Creating 'prod' namespace..."
+kubectl create namespace prod --dry-run=client -o yaml | kubectl apply -f -
+
+# Step 4: Create NGINX deployment in 'prod'
+echo "Creating NGINX deployment 'web-app' in 'prod' namespace..."
+kubectl apply -n prod -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-app
+  template:
+    metadata:
+      labels:
+        app: web-app
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:stable
+        ports:
+        - containerPort: 80
+EOF
+
+# Step 5: Expose the deployment as a ClusterIP service
+echo "Creating ClusterIP service 'web-app-svc'..."
+kubectl apply -n prod -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-app-svc
+spec:
+  selector:
+    app: web-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP
+EOF
+
+# Step 6: Add host entry to /etc/hosts
+echo "Adding entry to /etc/hosts..."
+HOST_ENTRY="172.30.1.2 prod.techiescamp.com"
+if ! grep -q "$HOST_ENTRY" /etc/hosts; then
+  echo "$HOST_ENTRY" | sudo tee -a /etc/hosts
+  echo "Entry added to /etc/hosts."
+else
+  echo "Entry already exists in /etc/hosts. Skipping..."
+fi
+
+echo "All tasks completed."

--- a/lessons/gateway-api/scenarios/02/destroy.sh
+++ b/lessons/gateway-api/scenarios/02/destroy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Step 1: Delete the 'secure' namespace (includes all resources inside)
+echo "Deleting 'secure' namespace and all its resources..."
+kubectl delete namespace secure --ignore-not-found
+
+# Step 2: Remove the hosts entry for secureapp.techiescamp.com
+HOST_ENTRY="172.30.1.2 secureapp.techiescamp.com"
+echo "Removing host entry from /etc/hosts..."
+if grep -q "$HOST_ENTRY" /etc/hosts; then
+  sudo sed -i.bak "/$HOST_ENTRY/d" /etc/hosts
+  echo "Entry removed."
+else
+  echo "Entry not found in /etc/hosts. Skipping..."
+fi
+
+echo "✅ Cleanup complete. Gateway API CRDs and controller are preserved."

--- a/lessons/gateway-api/scenarios/02/setup.sh
+++ b/lessons/gateway-api/scenarios/02/setup.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -e
+
+# Step 1: Check and apply Gateway API CRDs
+echo "Checking for Gateway API CRDs..."
+if ! kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+  echo "Installing Gateway API CRDs..."
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+else
+  echo "Gateway API CRDs already installed. Skipping..."
+fi
+
+# Step 2: Check and install NGINX Gateway Fabric controller
+echo "Checking for NGINX Gateway Fabric release..."
+if ! helm list -n nginx-gateway | grep -q "^ngf"; then
+  echo "Installing NGINX Gateway Fabric..."
+  helm install ngf oci://ghcr.io/nginxinc/charts/nginx-gateway-fabric --create-namespace -n nginx-gateway
+else
+  echo "NGINX Gateway Fabric already installed. Skipping..."
+fi
+
+# Step 3: Create 'secure' namespace
+echo "Creating 'secure' namespace..."
+kubectl create namespace secure --dry-run=client -o yaml | kubectl apply -f -
+
+# Step 4: Create Deployment in 'secure' namespace
+echo "Creating NGINX Deployment 'secureapp'..."
+kubectl apply -n secure -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secureapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: secureapp
+  template:
+    metadata:
+      labels:
+        app: secureapp
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:stable
+        ports:
+        - containerPort: 80
+EOF
+
+# Step 5: Create Service
+echo "Creating Service 'secureapp-svc'..."
+kubectl apply -n secure -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: secureapp-svc
+spec:
+  selector:
+    app: secureapp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP
+EOF
+
+# Step 6: Generate TLS cert and key
+echo "Generating TLS certificate and key for secureapp.techiescamp.com..."
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -subj "/CN=secureapp.techiescamp.com/O=secureapp" \
+  -keyout tls.key -out tls.crt
+
+# Step 7: Create TLS secret
+echo "Creating TLS secret 'secure-tls'..."
+kubectl create secret tls secure-tls \
+  --cert=tls.crt --key=tls.key -n secure
+
+# Cleanup local files
+rm tls.crt tls.key
+
+# Step 8: Add /etc/hosts entry
+HOST_ENTRY="172.30.1.2 secureapp.techiescamp.com"
+echo "Adding entry to /etc/hosts..."
+if ! grep -q "$HOST_ENTRY" /etc/hosts; then
+  echo "$HOST_ENTRY" | sudo tee -a /etc/hosts
+  echo "Entry added."
+else
+  echo "Entry already exists. Skipping..."
+fi
+
+echo "✅ Setup complete."

--- a/lessons/gateway-api/scenarios/03/destroy.sh
+++ b/lessons/gateway-api/scenarios/03/destroy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+# Step 1: Delete the Ingress
+echo "Deleting Ingress 'legacyweb-ingress'..."
+kubectl delete ingress legacyweb-ingress -n default --ignore-not-found
+
+# Step 2: Delete the Service
+echo "Deleting Service 'legacyweb'..."
+kubectl delete service legacyweb -n default --ignore-not-found
+
+# Step 3: Delete the Deployment
+echo "Deleting Deployment 'legacyweb'..."
+kubectl delete deployment legacyweb -n default --ignore-not-found
+
+# Step 4: Remove the /etc/hosts entry
+HOST_ENTRY="172.30.1.2 legacyweb.techiescamp.com"
+echo "Removing host entry from /etc/hosts..."
+if grep -q "$HOST_ENTRY" /etc/hosts; then
+  sudo sed -i.bak "/$HOST_ENTRY/d" /etc/hosts
+  echo "Entry removed."
+else
+  echo "Entry not found in /etc/hosts. Skipping..."
+fi
+
+echo "✅ Cleanup complete. CRDs and NGINX Gateway controller are preserved."

--- a/lessons/gateway-api/scenarios/03/setup.sh
+++ b/lessons/gateway-api/scenarios/03/setup.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -e
+
+# Step 1: Check and apply Gateway API CRDs
+echo "Checking for Gateway API CRDs..."
+if ! kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+  echo "Installing Gateway API CRDs..."
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+else
+  echo "Gateway API CRDs already installed. Skipping..."
+fi
+
+# Step 2: Check and install NGINX Gateway Fabric controller
+echo "Checking for NGINX Gateway Fabric release..."
+if ! helm list -n nginx-gateway | grep -q "^ngf"; then
+  echo "Installing NGINX Gateway Fabric..."
+  helm install ngf oci://ghcr.io/nginxinc/charts/nginx-gateway-fabric --create-namespace -n nginx-gateway
+else
+  echo "NGINX Gateway Fabric already installed. Skipping..."
+fi
+
+# Step 3: Deploy NGINX app in default namespace
+echo "Deploying NGINX Deployment 'legacyweb' in 'default' namespace..."
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: legacyweb
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: legacyweb
+  template:
+    metadata:
+      labels:
+        app: legacyweb
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:stable
+        ports:
+        - containerPort: 80
+EOF
+
+# Step 4: Create ClusterIP service
+echo "Creating ClusterIP Service 'legacyweb'..."
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: legacyweb
+  namespace: default
+spec:
+  selector:
+    app: legacyweb
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP
+EOF
+
+# Step 5: Create Ingress object (named legacyweb-ingress)
+echo "Creating Ingress 'legacyweb-ingress'..."
+kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: legacyweb-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: legacyweb.techiescamp.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: legacyweb
+            port:
+              number: 80
+EOF
+
+# Step 6: Add entry to /etc/hosts
+HOST_ENTRY="172.30.1.2 legacyweb.techiescamp.com"
+echo "Adding entry to /etc/hosts..."
+if ! grep -q "$HOST_ENTRY" /etc/hosts; then
+  echo "$HOST_ENTRY" | sudo tee -a /etc/hosts
+  echo "Entry added."
+else
+  echo "Entry already exists. Skipping..."
+fi
+
+echo "✅ Setup complete for legacyweb.techiescamp.com"

--- a/lessons/gateway-api/scenarios/04/destroy.sh
+++ b/lessons/gateway-api/scenarios/04/destroy.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+# Step 1: Delete HTTPRoute
+echo "Deleting HTTPRoute 'frontend-route'..."
+kubectl delete httproute frontend-route -n frontend --ignore-not-found
+
+# Step 2: Delete Gateway
+echo "Deleting Gateway 'frontend-gateway'..."
+kubectl delete gateway frontend-gateway -n frontend --ignore-not-found
+
+# Step 3: Delete frontendapp Deployment and Service
+echo "Deleting frontendapp deployment and service..."
+kubectl delete deployment frontendapp -n frontend --ignore-not-found
+kubectl delete service frontendapp-svc -n frontend --ignore-not-found
+
+# Step 4: Delete backendapp Deployment and Service
+echo "Deleting backendapp deployment and service..."
+kubectl delete deployment backendapp -n backend --ignore-not-found
+kubectl delete service backendapp-svc -n backend --ignore-not-found
+
+# Step 5: Delete frontend and backend namespaces
+echo "Deleting namespaces 'frontend' and 'backend'..."
+kubectl delete namespace frontend --ignore-not-found
+kubectl delete namespace backend --ignore-not-found
+
+# Step 6: Remove /etc/hosts entries
+echo "Removing /etc/hosts entries..."
+for host in frontend.techiescamp.com backend.techiescamp.com; do
+  HOST_ENTRY="172.30.1.2 $host"
+  if grep -q "$HOST_ENTRY" /etc/hosts; then
+    sudo sed -i.bak "/$HOST_ENTRY/d" /etc/hosts
+    echo "Removed: $HOST_ENTRY"
+  else
+    echo "Not found in /etc/hosts: $HOST_ENTRY"
+  fi
+done
+
+echo "✅ Cleanup complete. CRDs and Gateway controller are preserved."

--- a/lessons/gateway-api/scenarios/04/setup.sh
+++ b/lessons/gateway-api/scenarios/04/setup.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+set -e
+
+# Step 1: Install Gateway API CRDs if not already installed
+echo "Checking for Gateway API CRDs..."
+if ! kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+  echo "Installing Gateway API CRDs..."
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+else
+  echo "Gateway API CRDs already installed. Skipping..."
+fi
+
+# Step 2: Install NGINX Gateway Fabric if not already installed
+echo "Checking for NGINX Gateway Fabric..."
+if ! helm list -n nginx-gateway | grep -q "^ngf"; then
+  echo "Installing NGINX Gateway Fabric..."
+  helm install ngf oci://ghcr.io/nginxinc/charts/nginx-gateway-fabric --create-namespace -n nginx-gateway
+else
+  echo "NGINX Gateway Fabric already installed. Skipping..."
+fi
+
+# Step 3: Create backend namespace
+echo "Creating namespace 'backend'..."
+kubectl create namespace backend --dry-run=client -o yaml | kubectl apply -f -
+
+# Step 4: Deploy backendapp in backend namespace
+echo "Creating backendapp deployment..."
+kubectl apply -n backend -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backendapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backendapp
+  template:
+    metadata:
+      labels:
+        app: backendapp
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:stable
+        ports:
+        - containerPort: 80
+EOF
+
+# Step 5: Create backendapp-svc
+echo "Creating backendapp-svc..."
+kubectl apply -n backend -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendapp-svc
+spec:
+  selector:
+    app: backendapp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+EOF
+
+# Step 6: Create frontend namespace
+echo "Creating namespace 'frontend'..."
+kubectl create namespace frontend --dry-run=client -o yaml | kubectl apply -f -
+
+# Step 7: Create frontendapp deployment
+echo "Creating frontendapp deployment..."
+kubectl apply -n frontend -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontendapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontendapp
+  template:
+    metadata:
+      labels:
+        app: frontendapp
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:stable
+        ports:
+        - containerPort: 80
+EOF
+
+# Step 8: Create frontendapp-svc
+echo "Creating frontendapp-svc..."
+kubectl apply -n frontend -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontendapp-svc
+spec:
+  selector:
+    app: frontendapp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+EOF
+
+# Step 9: Create Gateway in frontend (using existing GatewayClass 'nginx')
+echo "Creating Gateway 'frontend-gateway' in 'frontend' namespace..."
+kubectl apply -n frontend -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: frontend-gateway
+spec:
+  gatewayClassName: nginx
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    hostname: "frontend.techiescamp.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+EOF
+
+# Step 10: Create HTTPRoute for frontend
+echo "Creating HTTPRoute 'frontend-route'..."
+kubectl apply -n frontend -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frontend-route
+spec:
+  parentRefs:
+  - name: frontend-gateway
+  hostnames:
+  - "frontend.techiescamp.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: frontendapp-svc
+      port: 80
+EOF
+
+# Step 11: Add /etc/hosts entries
+echo "Adding entries to /etc/hosts..."
+for host in frontend.techiescamp.com backend.techiescamp.com; do
+  HOST_ENTRY="172.30.1.2 $host"
+  if ! grep -q "$HOST_ENTRY" /etc/hosts; then
+    echo "$HOST_ENTRY" | sudo tee -a /etc/hosts
+    echo "Entry added: $HOST_ENTRY"
+  else
+    echo "Entry already exists: $HOST_ENTRY"
+  fi
+done
+
+echo "✅ Setup complete: frontend and backend apps are deployed. Gateway configured only for frontend."


### PR DESCRIPTION
Introduced setup.sh and destroy.sh scripts for four Gateway API scenarios, automating deployment and cleanup of namespaces, services, deployments, Ingress/HTTPRoute, Gateway resources, and /etc/hosts entries. These scripts streamline environment preparation and teardown for hands-on Kubernetes Gateway API lessons.