### PR TITLE
Update app and gateway to use port 8080 instead of 80

### DIFF
--- a/helm-charts/nginx-gateway-fabric/values.yaml
+++ b/helm-charts/nginx-gateway-fabric/values.yaml
@@ -460,6 +460,8 @@ nginx:
     nodePorts:
     - port: 32000
       listenerPort: 80
+    - port: 32500
+      listenerPort: 8080
     - port: 32443
       listenerPort: 443
     # -- Enable debugging for NGINX. Uses the nginx-debug binary. The NGINX error log level should be set to debug in the NginxProxy resource.

--- a/lessons/gateway-api/canary-deployment/app-deployment.yaml
+++ b/lessons/gateway-api/canary-deployment/app-deployment.yaml
@@ -65,7 +65,7 @@ spec:
   selector:
     app: app-v1
   ports:
-  - port: 80
+  - port: 8080
     targetPort: 80
 ---
 apiVersion: apps/v1
@@ -104,7 +104,7 @@ spec:
   selector:
     app: app-v2
   ports:
-  - port: 80
+  - port: 8080
     targetPort: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -116,6 +116,6 @@ spec:
   gatewayClassName: nginx-gateway-class
   listeners:
   - name: http
-    port: 80
+    port: 8080
     protocol: HTTP
     hostname: "app.techiescamp.com"


### PR DESCRIPTION
Changed service and deployment ports from 80 to 8080 in the canary deployment lesson. Updated Helm values to expose listenerPort 8080 on nodePort 32500 for NGINX Gateway Fabric. This aligns the deployment and gateway configuration to use port 8080.