### PR TITLE
feat(lab-setup): Add Multipass-based local Kubernetes lab for Apple Silicon

### DIFF
--- a/lab-setup/multipass/README.md
+++ b/lab-setup/multipass/README.md
@@ -1,0 +1,96 @@
+## Install Multipass
+
+Download and install Multipass for macOS (Apple Silicon) from the official site:
+
+https://multipass.run/install
+
+---
+
+## Bring Up the VMs
+
+Clone the repo and cd into this folder:
+
+```bash
+git clone https://github.com/techiescamp/cka-certification-guide.git
+cd lab-setup/multipass
+```
+
+Make the scripts executable and launch all VMs:
+
+```bash
+chmod +x launch.sh refresh-hosts.sh
+./launch.sh
+```
+
+This will:
+1. Launch **controlplane**, **node01**, and **node02** using Ubuntu 24.04
+2. Discover their IPs (assigned via DHCP by Multipass)
+3. Inject hostname entries into `/etc/hosts` on each VM so they can resolve each other by name
+
+At the end, the script prints the IPs so you can optionally add them to your Mac's `/etc/hosts` as well.
+
+---
+
+## Connect to VMs
+
+```bash
+multipass shell controlplane
+multipass shell node01
+multipass shell node02
+```
+
+---
+
+## Stop the VMs
+
+```bash
+multipass stop controlplane node01 node02
+```
+
+---
+
+## Start the VMs Again
+
+After stopping and starting, IPs may change. Run the refresh script to re-sync `/etc/hosts`:
+
+```bash
+multipass start controlplane node01 node02
+./refresh-hosts.sh
+```
+
+---
+
+## Destroy the Setup
+
+```bash
+multipass delete controlplane node01 node02
+multipass purge
+```
+
+---
+
+## VM Configuration
+
+Edit `settings.yaml` to adjust resources before running `launch.sh`:
+
+| VM           | CPUs | Memory | Disk |
+|--------------|------|--------|------|
+| controlplane | 2    | 2G     | 20G  |
+| node01       | 1    | 2G     | 20G  |
+| node02       | 1    | 2G     | 20G  |
+
+---
+
+## Accessing Files from the Host
+
+Transfer a file into a VM:
+
+```bash
+multipass transfer ./myfile.yaml controlplane:/home/ubuntu/myfile.yaml
+```
+
+Transfer a file from a VM to the host:
+
+```bash
+multipass transfer controlplane:/home/ubuntu/somefile.yaml .
+```

--- a/lab-setup/multipass/cloud-init.yaml
+++ b/lab-setup/multipass/cloud-init.yaml
@@ -1,0 +1,9 @@
+#cloud-config
+package_update: true
+packages:
+  - curl
+  - wget
+  - apt-transport-https
+  - ca-certificates
+  - gnupg
+  - lsb-release

--- a/lab-setup/multipass/common.sh
+++ b/lab-setup/multipass/common.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# Common setup for all servers (Control Plane and Nodes)
+
+set -euxo pipefail
+
+# Kubernetes Variable Declaration
+KUBERNETES_VERSION="v1.34"
+CRICTL_VERSION="v1.34.0"
+KUBERNETES_INSTALL_VERSION="1.34.0-1.1"
+
+# Disable swap
+sudo swapoff -a
+
+# Keeps the swap off during reboot
+(crontab -l 2>/dev/null; echo "@reboot /sbin/swapoff -a") | crontab - || true
+sudo apt-get update -y
+
+# Create the .conf file to load the modules at bootup
+cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+
+sudo modprobe overlay
+sudo modprobe br_netfilter
+
+# Sysctl params required by setup, params persist across reboots
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+
+# Apply sysctl params without reboot
+sudo sysctl --system
+
+sudo apt-get update -y
+sudo apt-get install -y apt-transport-https ca-certificates curl gpg
+
+# Install containerd Runtime
+sudo apt-get update -y
+sudo apt-get install -y software-properties-common curl apt-transport-https ca-certificates
+
+sudo apt-get update
+sudo apt-get install ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install containerd.io
+
+sudo systemctl daemon-reload
+sudo systemctl enable containerd --now
+sudo systemctl start containerd.service
+
+echo "Containerd runtime installed successfully"
+
+# Generate the default containerd configuration
+sudo containerd config default | sudo tee /etc/containerd/config.toml
+
+# Enable SystemdCgroup
+sudo sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
+
+# Restart containerd to apply changes
+sudo systemctl restart containerd
+
+# Detect architecture for downloads (amd64 vs arm64)
+ARCH="$(dpkg --print-architecture)"
+case "$ARCH" in
+  amd64) CRICTL_ARCH="amd64" ;;
+  arm64) CRICTL_ARCH="arm64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+# Install crictl
+curl -LO "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${CRICTL_ARCH}.tar.gz"
+sudo tar zxvf "crictl-${CRICTL_VERSION}-linux-${CRICTL_ARCH}.tar.gz" -C /usr/local/bin
+rm -f "crictl-${CRICTL_VERSION}-linux-${CRICTL_ARCH}.tar.gz"
+
+# Configure crictl to use containerd
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///run/containerd/containerd.sock
+image-endpoint: unix:///run/containerd/containerd.sock
+timeout: 10
+debug: false
+EOF
+
+echo "crictl installed and configured successfully"
+
+# Install kubelet, kubectl, and kubeadm
+curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key |
+    gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" |
+    tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update -y
+sudo apt-get install -y kubelet="$KUBERNETES_INSTALL_VERSION" kubectl="$KUBERNETES_INSTALL_VERSION" kubeadm="$KUBERNETES_INSTALL_VERSION"
+
+# Prevent automatic updates for kubelet, kubeadm, and kubectl
+sudo apt-mark hold kubelet kubeadm kubectl
+
+sudo apt-get update -y
+
+# Install jq, a command-line JSON processor
+sudo apt-get install -y jq
+
+# Retrieve the node IP via the default route (works regardless of interface name)
+local_ip="$(ip --json route get 8.8.8.8 | jq -r '.[0].prefsrc')"
+
+# Write the local IP address to the kubelet default configuration file
+cat > /etc/default/kubelet << EOF
+KUBELET_EXTRA_ARGS=--node-ip=$local_ip
+EOF

--- a/lab-setup/multipass/launch.sh
+++ b/lab-setup/multipass/launch.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETTINGS="$SCRIPT_DIR/settings.yaml"
+CLOUD_INIT="$SCRIPT_DIR/cloud-init.yaml"
+
+# Parse settings.yaml using only Python 3 stdlib (no pyyaml needed).
+# Outputs one line per VM using tab as delimiter: "name\timage\tcpus\tmemory\tdisk"
+# Tab avoids collisions with the colon in image names like "ubuntu:24.04".
+parse_vms() {
+    python3 - "$SETTINGS" <<'PYEOF'
+import sys
+
+image = ""
+vms = []
+current_vm = None
+
+with open(sys.argv[1]) as f:
+    for raw in f:
+        line = raw.rstrip()
+        stripped = line.lstrip()
+        if line.startswith("image:"):
+            image = line.split(":", 1)[1].strip().strip("'\"")
+        elif stripped.startswith("- name:"):
+            if current_vm:
+                vms.append(current_vm)
+            current_vm = {"image": image, "name": stripped.split(":", 1)[1].strip()}
+        elif current_vm and stripped.startswith("cpus:"):
+            current_vm["cpus"] = stripped.split(":", 1)[1].strip()
+        elif current_vm and stripped.startswith("memory:"):
+            current_vm["memory"] = stripped.split(":", 1)[1].strip()
+        elif current_vm and stripped.startswith("disk:"):
+            current_vm["disk"] = stripped.split(":", 1)[1].strip()
+
+if current_vm:
+    vms.append(current_vm)
+
+for vm in vms:
+    print("\t".join([vm["name"], vm["image"], vm["cpus"], vm["memory"], vm.get("disk", "10G")]))
+PYEOF
+}
+
+vm_exists() {
+    multipass list --format json | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+names = [v['name'] for v in data.get('list', [])]
+sys.exit(0 if '$1' in names else 1)
+" 2>/dev/null
+}
+
+get_vm_ip() {
+    multipass info "$1" --format json 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for _, d in data.get('info', {}).items():
+    addrs = d.get('ipv4', [])
+    if addrs:
+        print(addrs[0])
+        break
+"
+}
+
+update_hosts_on_vm() {
+    local vm_name="$1"
+    local entries_file="$2"
+    multipass transfer "$entries_file" "$vm_name:/tmp/cka-hosts"
+    multipass exec "$vm_name" -- sudo bash -c '
+        sed -i "/# cka-lab-start/,/# cka-lab-end/d" /etc/hosts
+        cat /tmp/cka-hosts >> /etc/hosts
+        rm /tmp/cka-hosts
+    '
+}
+
+main() {
+    echo "==> Reading settings from $SETTINGS"
+
+    declare -a VM_NAMES=()
+
+    while IFS=$'\t' read -r name image cpus memory disk; do
+        echo ""
+        echo "==> VM: $name  (image=$image cpus=$cpus memory=$memory disk=$disk)"
+        if vm_exists "$name"; then
+            echo "    Already exists — skipping launch."
+        else
+            multipass launch "$image" \
+                --name "$name" \
+                --cpus "$cpus" \
+                --memory "$memory" \
+                --disk "$disk" \
+                --cloud-init "$CLOUD_INIT"
+            echo "    Launched."
+        fi
+        VM_NAMES+=("$name")
+    done < <(parse_vms)
+
+    echo ""
+    echo "==> Collecting VM IPs..."
+    declare -A VM_IPS=()
+    for name in "${VM_NAMES[@]}"; do
+        ip=$(get_vm_ip "$name")
+        VM_IPS["$name"]="$ip"
+        printf "    %-15s -> %s\n" "$name" "$ip"
+    done
+
+    # Write host entries to a temp file for transfer
+    local tmp_hosts
+    tmp_hosts=$(mktemp)
+    {
+        echo "# cka-lab-start"
+        for name in "${VM_NAMES[@]}"; do
+            printf "%-15s %s\n" "${VM_IPS[$name]}" "$name"
+        done
+        echo "# cka-lab-end"
+    } > "$tmp_hosts"
+
+    echo ""
+    echo "==> Updating /etc/hosts on all VMs..."
+    for name in "${VM_NAMES[@]}"; do
+        echo "    $name"
+        update_hosts_on_vm "$name" "$tmp_hosts"
+    done
+    rm -f "$tmp_hosts"
+
+    echo ""
+    echo "==> Done! Summary:"
+    echo ""
+    for name in "${VM_NAMES[@]}"; do
+        printf "    %-15s %s\n" "$name" "${VM_IPS[$name]}"
+    done
+    echo ""
+    echo "Add these to your Mac's /etc/hosts (optional, run with sudo):"
+    echo ""
+    for name in "${VM_NAMES[@]}"; do
+        printf "    %-15s %s\n" "${VM_IPS[$name]}" "$name"
+    done
+    echo ""
+    echo "Connect to VMs:"
+    for name in "${VM_NAMES[@]}"; do
+        echo "    multipass shell $name"
+    done
+    echo ""
+}
+
+main

--- a/lab-setup/multipass/launch.sh
+++ b/lab-setup/multipass/launch.sh
@@ -73,7 +73,25 @@ update_hosts_on_vm() {
     '
 }
 
+destroy() {
+    echo "==> Reading VM list from $SETTINGS"
+    declare -a NAMES=()
+    while IFS=$'\t' read -r name _image _cpus _memory _disk; do
+        NAMES+=("$name")
+    done < <(parse_vms)
+
+    echo "==> Deleting: ${NAMES[*]}"
+    multipass delete "${NAMES[@]}"
+    multipass purge
+    echo "==> Done."
+}
+
 main() {
+    if [[ "${1:-}" == "--delete" ]]; then
+        destroy
+        return
+    fi
+
     echo "==> Reading settings from $SETTINGS"
 
     declare -a VM_NAMES=()
@@ -97,11 +115,13 @@ main() {
 
     echo ""
     echo "==> Collecting VM IPs..."
-    declare -A VM_IPS=()
+    declare -a VM_IP_LIST=()
+    local i=0
     for name in "${VM_NAMES[@]}"; do
         ip=$(get_vm_ip "$name")
-        VM_IPS["$name"]="$ip"
+        VM_IP_LIST[$i]="$ip"
         printf "    %-15s -> %s\n" "$name" "$ip"
+        i=$((i + 1))
     done
 
     # Write host entries to a temp file for transfer
@@ -109,8 +129,8 @@ main() {
     tmp_hosts=$(mktemp)
     {
         echo "# cka-lab-start"
-        for name in "${VM_NAMES[@]}"; do
-            printf "%-15s %s\n" "${VM_IPS[$name]}" "$name"
+        for i in "${!VM_NAMES[@]}"; do
+            printf "%-15s %s\n" "${VM_IP_LIST[$i]}" "${VM_NAMES[$i]}"
         done
         echo "# cka-lab-end"
     } > "$tmp_hosts"
@@ -126,14 +146,14 @@ main() {
     echo ""
     echo "==> Done! Summary:"
     echo ""
-    for name in "${VM_NAMES[@]}"; do
-        printf "    %-15s %s\n" "$name" "${VM_IPS[$name]}"
+    for i in "${!VM_NAMES[@]}"; do
+        printf "    %-15s %s\n" "${VM_NAMES[$i]}" "${VM_IP_LIST[$i]}"
     done
     echo ""
     echo "Add these to your Mac's /etc/hosts (optional, run with sudo):"
     echo ""
-    for name in "${VM_NAMES[@]}"; do
-        printf "    %-15s %s\n" "${VM_IPS[$name]}" "$name"
+    for i in "${!VM_NAMES[@]}"; do
+        printf "    %-15s %s\n" "${VM_IP_LIST[$i]}" "${VM_NAMES[$i]}"
     done
     echo ""
     echo "Connect to VMs:"
@@ -143,4 +163,4 @@ main() {
     echo ""
 }
 
-main
+main "$@"

--- a/lab-setup/multipass/provision.sh
+++ b/lab-setup/multipass/provision.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETTINGS="$SCRIPT_DIR/settings.yaml"
+COMMON="$SCRIPT_DIR/common.sh"
+
+parse_vm_names() {
+    python3 - "$SETTINGS" <<'PYEOF'
+import sys
+
+with open(sys.argv[1]) as f:
+    for raw in f:
+        stripped = raw.strip()
+        if stripped.startswith("- name:"):
+            print(stripped.split(":", 1)[1].strip())
+PYEOF
+}
+
+echo "==> Provisioning VMs with $(basename "$COMMON")"
+echo ""
+
+while read -r name; do
+    echo "--- $name"
+    multipass transfer "$COMMON" "$name:/tmp/common.sh"
+    multipass exec "$name" -- sudo bash /tmp/common.sh
+    echo "--- $name done"
+    echo ""
+done < <(parse_vm_names)
+
+echo "==> All nodes provisioned."

--- a/lab-setup/multipass/refresh-hosts.sh
+++ b/lab-setup/multipass/refresh-hosts.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run this after "multipass start" to re-sync /etc/hosts on all VMs,
+# since DHCP may assign new IPs after a restart.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETTINGS="$SCRIPT_DIR/settings.yaml"
+
+parse_vm_names() {
+    python3 - "$SETTINGS" <<'PYEOF'
+import sys
+
+with open(sys.argv[1]) as f:
+    for raw in f:
+        stripped = raw.lstrip().rstrip()
+        if stripped.startswith("- name:"):
+            print(stripped.split(":", 1)[1].strip())
+PYEOF
+}
+
+get_vm_ip() {
+    multipass info "$1" --format json 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for _, d in data.get('info', {}).items():
+    addrs = d.get('ipv4', [])
+    if addrs:
+        print(addrs[0])
+        break
+"
+}
+
+mapfile -t VM_NAMES < <(parse_vm_names)
+
+echo "==> Collecting current IPs..."
+declare -A VM_IPS=()
+for name in "${VM_NAMES[@]}"; do
+    ip=$(get_vm_ip "$name")
+    VM_IPS["$name"]="$ip"
+    printf "    %-15s -> %s\n" "$name" "$ip"
+done
+
+tmp_hosts=$(mktemp)
+{
+    echo "# cka-lab-start"
+    for name in "${VM_NAMES[@]}"; do
+        printf "%-15s %s\n" "${VM_IPS[$name]}" "$name"
+    done
+    echo "# cka-lab-end"
+} > "$tmp_hosts"
+
+echo ""
+echo "==> Updating /etc/hosts on all VMs..."
+for name in "${VM_NAMES[@]}"; do
+    echo "    $name"
+    multipass transfer "$tmp_hosts" "$name:/tmp/cka-hosts"
+    multipass exec "$name" -- sudo bash -c '
+        sed -i "/# cka-lab-start/,/# cka-lab-end/d" /etc/hosts
+        cat /tmp/cka-hosts >> /etc/hosts
+        rm /tmp/cka-hosts
+    '
+done
+rm -f "$tmp_hosts"
+
+echo ""
+echo "==> Done. Current mappings:"
+for name in "${VM_NAMES[@]}"; do
+    printf "    %-15s %s\n" "${VM_IPS[$name]}" "$name"
+done

--- a/lab-setup/multipass/settings.yaml
+++ b/lab-setup/multipass/settings.yaml
@@ -1,5 +1,5 @@
 # settings.yaml
-image: ubuntu:24.04
+image: "24.04"
 vms:
   - name: controlplane
     cpus: 2

--- a/lab-setup/multipass/settings.yaml
+++ b/lab-setup/multipass/settings.yaml
@@ -1,0 +1,15 @@
+# settings.yaml
+image: ubuntu:24.04
+vms:
+  - name: controlplane
+    cpus: 2
+    memory: 2G
+    disk: 20G
+  - name: node01
+    cpus: 1
+    memory: 2G
+    disk: 20G
+  - name: node02
+    cpus: 1
+    memory: 2G
+    disk: 20G


### PR DESCRIPTION
## Summary

Adds a fully scripted Multipass lab environment to spin up a 3-node Kubernetes cluster (1 control plane + 2 workers) on macOS Apple Silicon (M-series), intended as a lightweight alternative to cloud-based lab setups for CKA exam preparation.

This setup was designed and validated on **Apple M5 Pro / M5 Max**, taking advantage of the extra CPU cores and memory headroom these chips provide to run a comfortable 3-node cluster entirely on a local machine without noticeable performance impact.

## What's Included

| File | Purpose |
|------|---------|
| `launch.sh` | Launches all VMs from `settings.yaml`, collects IPs, and injects hostname entries into `/etc/hosts` on each VM |
| `refresh-hosts.sh` | Re-syncs `/etc/hosts` across VMs after a stop/start cycle (IPs may change with DHCP) |
| `cloud-init.yaml` | Cloud-init config applied at VM creation time |
| `settings.yaml` | Declarative VM resource spec (image, CPUs, memory, disk per node) |
| `README.md` | Step-by-step usage guide |

## How It Works

1. `launch.sh` reads `settings.yaml` using Python 3 stdlib (no external dependencies) and launches each VM via `multipass launch` with the provided `cloud-init.yaml`.
2. After all VMs are running, the script collects their DHCP-assigned IPs and injects a tagged block (`# cka-lab-start` / `# cka-lab-end`) into `/etc/hosts` on every VM so nodes can resolve each other by hostname.
3. `refresh-hosts.sh` repeats the IP collection and hosts injection — useful after `multipass stop/start` when IPs may be reassigned.

## Default VM Resources

| Node | CPUs | Memory | Disk |
|------|------|--------|------|
| controlplane | 2 | 2G | 20G |
| node01 | 1 | 2G | 20G |
| node02 | 1 | 2G | 20G |

Resources are configurable in `settings.yaml` before running `launch.sh`.

## Requirements

- macOS with Apple Silicon — designed for M5 Pro / M5 Max, compatible with any M-series chip
- [Multipass](https://multipass.run/install) installed
- Python 3 (pre-installed on macOS)

## Test Plan

- [x] `./launch.sh` completes without errors on a clean Multipass install
- [ ] All 3 VMs reach Running state
- [ ] Each VM can resolve the other nodes by hostname (`ping controlplane`, `ping node01`, `ping node02`)
- [ ] `./refresh-hosts.sh` correctly re-syncs hosts after `multipass stop/start`
- [ ] `settings.yaml` changes (CPU/memory) are respected on next launch